### PR TITLE
[bug] Fix RODC check in AuditUnconstrainedDelegations to compare against correct UAC flag (#21)

### DIFF
--- a/core/mode_audit/UnconstrainedDelegations.go
+++ b/core/mode_audit/UnconstrainedDelegations.go
@@ -60,7 +60,7 @@ func AuditUnconstrainedDelegations(ldapHost string, ldapPort int, creds *credent
 			auditString := ""
 			if userAccountControl&int(ldap_attributes.UAF_SERVER_TRUST_ACCOUNT) == int(ldap_attributes.UAF_SERVER_TRUST_ACCOUNT) {
 				auditString = "(\x1b[92mLegitimate\x1b[0m: DC)"
-			} else if userAccountControl&int(ldap_attributes.UAF_PARTIAL_SECRETS_ACCOUNT) == int(ldap_attributes.UAF_SERVER_TRUST_ACCOUNT) {
+			} else if userAccountControl&int(ldap_attributes.UAF_PARTIAL_SECRETS_ACCOUNT) == int(ldap_attributes.UAF_PARTIAL_SECRETS_ACCOUNT) {
 				auditString = "(\x1b[91mSuspicious\x1b[0m: RODCs do not have unconstrained delegation by default)"
 			} else {
 				auditString = "(\x1b[91mSuspicious\x1b[0m)"


### PR DESCRIPTION
### Linked Issue
Closes #21

### Root Cause
The RODC branch in `AuditUnconstrainedDelegations` masked `userAccountControl` with `UAF_PARTIAL_SECRETS_ACCOUNT` (the RODC flag) but then compared the result against `UAF_SERVER_TRUST_ACCOUNT` (the DC flag) — a copy/paste mistake from the preceding DC branch. Because `UAF_PARTIAL_SECRETS_ACCOUNT = 1<<27` and `UAF_SERVER_TRUST_ACCOUNT = 1<<13`, the masked value is always either `0` or `1<<27`, so the equality check is unreachable and the RODC-specific audit message is never emitted.

### Fix Description
Change the right-hand side of the comparison to `UAF_PARTIAL_SECRETS_ACCOUNT` so the branch actually detects RODCs. This is the idiomatic `flag & X == X` pattern used elsewhere in the same file and in the modules' mode_* packages.

### How Verified
Static verification in the corrected code path at `core/mode_audit/UnconstrainedDelegations.go:63`: for an RODC object (`userAccountControl & (1<<27) != 0`), the masked value equals `1<<27 = UAF_PARTIAL_SECRETS_ACCOUNT`, so the equality holds and the RODC warning is now reachable. For non-RODC objects, the mask yields `0`, the equality fails, and the control falls through to the generic `Suspicious` branch unchanged.

Also verified by `go build ./...` after the change.

### Test Coverage
None. The audit functions in this repository are not covered by unit tests at the time of the fix; adding one would require mocking the `ldap.Session` surface, which is out of scope for a one-line defect correction.

### Scope of Change
- **Files changed:** `core/mode_audit/UnconstrainedDelegations.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local. Only affects the string emitted in the audit output for RODCs; no LDAP writes or state changes are involved.
