### PR TITLE
[bug] Fix RBCD audit/find tree prefix using shadowed inner ACE index (#23)

### DIFF
--- a/core/mode_audit/RessourceBasedConstrainedDelegations.go
+++ b/core/mode_audit/RessourceBasedConstrainedDelegations.go
@@ -79,15 +79,15 @@ func AuditRessourceBasedConstrainedDelegations(ldapHost string, ldapPort int, cr
 			if err != nil {
 				return fmt.Errorf("error creating security descriptor: %s", err)
 			}
-			for entryIndex, entry := range ntSecurityDescriptor.DACL.Entries {
+			for aceIndex, ace := range ntSecurityDescriptor.DACL.Entries {
 				var separator string
-				if entryIndex < len(ntSecurityDescriptor.DACL.Entries)-1 {
+				if aceIndex < len(ntSecurityDescriptor.DACL.Entries)-1 {
 					separator = "├──"
 				} else {
 					separator = "└──"
 				}
 
-				sidString := entry.Identity.SID.ToString()
+				sidString := ace.Identity.SID.ToString()
 				distingushedName, err := utils.LookupSID(&ldapSession, sidString)
 
 				// Format the string depending on if the SID lookup failed or not

--- a/core/mode_find/RessourceBasedConstrainedDelegations.go
+++ b/core/mode_find/RessourceBasedConstrainedDelegations.go
@@ -79,15 +79,15 @@ func FindRessourceBasedConstrainedDelegations(ldapHost string, ldapPort int, cre
 			if err != nil {
 				return fmt.Errorf("error creating security descriptor: %s", err)
 			}
-			for entryIndex, entry := range ntSecurityDescriptor.DACL.Entries {
+			for aceIndex, ace := range ntSecurityDescriptor.DACL.Entries {
 				var separator string
-				if entryIndex < len(ntSecurityDescriptor.DACL.Entries)-1 {
+				if aceIndex < len(ntSecurityDescriptor.DACL.Entries)-1 {
 					separator = "├──"
 				} else {
 					separator = "└──"
 				}
 
-				sidString := entry.Identity.SID.ToString()
+				sidString := ace.Identity.SID.ToString()
 				distingushedName, err := utils.LookupSID(&ldapSession, sidString)
 
 				// Format the string depending on if the SID lookup failed or not


### PR DESCRIPTION
### Linked Issue
Closes #23

### Root Cause
The inner loop over `ntSecurityDescriptor.DACL.Entries` reused the variable name `entryIndex` from the outer loop over `searchResults`, shadowing it inside the ACE loop body. The subsequent tree-prefix conditional `if entryIndex < len(searchResults)-1` then read the inner ACE index rather than the outer search-result index, so the `│` vs. spaces choice for the left-hand prefix was driven by the wrong value. The outer variable was unreachable within the inner loop.

This was a regression introduced by #18 (closed #17): before that change, the inner loop iterated over `values` with a distinct name (`valueIndex`). #18 moved the inner loop onto `DACL.Entries` and reused `entryIndex`, which is what produced the shadowing.

### Fix Description
Rename the inner loop variables from `entryIndex, entry` to `aceIndex, ace` in both `core/mode_audit/RessourceBasedConstrainedDelegations.go` and `core/mode_find/RessourceBasedConstrainedDelegations.go`. This removes the shadowing, so the outer `entryIndex`/`entry` bindings remain visible inside the inner loop body and the tree-prefix conditional now reads the outer search-result index as intended. The inner separator decision (`├──` vs. `└──`) keeps comparing against `len(DACL.Entries)-1`, now using the renamed `aceIndex`.

Renaming is preferred over introducing a captured outer-index variable because it keeps the fix diff-minimal, matches the naming used elsewhere in the package, and makes the two nesting levels unambiguous at a glance.

### How Verified
Static verification over the corrected code paths:

- `core/mode_audit/RessourceBasedConstrainedDelegations.go:82-107`: inner loop variables renamed; outer `entryIndex` and `len(searchResults)` are now the only referents for the `│` vs. spaces branch.
- `core/mode_find/RessourceBasedConstrainedDelegations.go:82-107`: same correction.

Also verified by `go build ./...` after the rename.

### Test Coverage
None. These audit/find functions are not unit-tested in the repository today; exercising them requires an LDAP session. The change is a rename-only correction inside a formatting path, and adding a test harness for that path is out of scope for this fix.

### Scope of Change
- **Files changed:**
  - `core/mode_audit/RessourceBasedConstrainedDelegations.go`
  - `core/mode_find/RessourceBasedConstrainedDelegations.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local. Only affects the text layout of RBCD output; no LDAP writes, no security decisions, no state changes.
