### PR TITLE
Fix unused --ignore-legitimate parameter in constrained and RBCD audits (Fixes #25)

### DIFF
--- a/main.go
+++ b/main.go
@@ -640,15 +640,15 @@ func main() {
 		if err != nil {
 			logger.Warn(fmt.Sprintf("Error auditing unconstrained delegations: %s", err))
 		}
-		err = mode_audit.AuditConstrainedDelegations(domainController, ldapPort, creds, useLdaps, useKerberos, distinguishedName, debug, ignoreLegitimate)
+		err = mode_audit.AuditConstrainedDelegations(domainController, ldapPort, creds, useLdaps, useKerberos, distinguishedName, debug)
 		if err != nil {
 			logger.Warn(fmt.Sprintf("Error auditing constrained delegations: %s", err))
 		}
-		err = mode_audit.AuditConstrainedDelegationsWithProtocolTransition(domainController, ldapPort, creds, useLdaps, useKerberos, distinguishedName, debug, ignoreLegitimate)
+		err = mode_audit.AuditConstrainedDelegationsWithProtocolTransition(domainController, ldapPort, creds, useLdaps, useKerberos, distinguishedName, debug)
 		if err != nil {
 			logger.Warn(fmt.Sprintf("Error auditing constrained delegations with protocol transition: %s", err))
 		}
-		err = mode_audit.AuditRessourceBasedConstrainedDelegations(domainController, ldapPort, creds, useLdaps, useKerberos, distinguishedName, debug, ignoreLegitimate)
+		err = mode_audit.AuditRessourceBasedConstrainedDelegations(domainController, ldapPort, creds, useLdaps, useKerberos, distinguishedName, debug)
 		if err != nil {
 			logger.Warn(fmt.Sprintf("Error auditing ressource-based constrained delegations: %s", err))
 		}

--- a/mode_audit/ConstrainedDelegations.go
+++ b/mode_audit/ConstrainedDelegations.go
@@ -24,7 +24,7 @@ import (
 // Returns:
 //
 //	An error if the operation fails, nil otherwise.
-func AuditConstrainedDelegations(ldapHost string, ldapPort int, creds *credentials.Credentials, useLdaps bool, useKerberos bool, distinguishedName string, debug bool, ignoreLegitimate bool) error {
+func AuditConstrainedDelegations(ldapHost string, ldapPort int, creds *credentials.Credentials, useLdaps bool, useKerberos bool, distinguishedName string, debug bool) error {
 	ldapSession := ldap.Session{}
 	ldapSession.InitSession(ldapHost, ldapPort, creds, useLdaps, useKerberos)
 	success, err := ldapSession.Connect()

--- a/mode_audit/ConstrainedDelegationsWithProtocolTransition.go
+++ b/mode_audit/ConstrainedDelegationsWithProtocolTransition.go
@@ -24,7 +24,7 @@ import (
 // Returns:
 //
 //	An error if the operation fails, nil otherwise.
-func AuditConstrainedDelegationsWithProtocolTransition(ldapHost string, ldapPort int, creds *credentials.Credentials, useLdaps bool, useKerberos bool, distinguishedName string, debug bool, ignoreLegitimate bool) error {
+func AuditConstrainedDelegationsWithProtocolTransition(ldapHost string, ldapPort int, creds *credentials.Credentials, useLdaps bool, useKerberos bool, distinguishedName string, debug bool) error {
 	ldapSession := ldap.Session{}
 	ldapSession.InitSession(ldapHost, ldapPort, creds, useLdaps, useKerberos)
 	success, err := ldapSession.Connect()

--- a/mode_audit/RessourceBasedConstrainedDelegations.go
+++ b/mode_audit/RessourceBasedConstrainedDelegations.go
@@ -24,7 +24,7 @@ import (
 // Returns:
 //
 //	An error if the operation fails, nil otherwise.
-func AuditRessourceBasedConstrainedDelegations(ldapHost string, ldapPort int, creds *credentials.Credentials, useLdaps bool, useKerberos bool, distinguishedName string, debug bool, ignoreLegitimate bool) error {
+func AuditRessourceBasedConstrainedDelegations(ldapHost string, ldapPort int, creds *credentials.Credentials, useLdaps bool, useKerberos bool, distinguishedName string, debug bool) error {
 	ldapSession := ldap.Session{}
 	ldapSession.InitSession(ldapHost, ldapPort, creds, useLdaps, useKerberos)
 	success, err := ldapSession.Connect()


### PR DESCRIPTION
### Linked Issue
`Closes #25`

### Root Cause
When `--ignore-legitimate` was added, the `ignoreLegitimate bool` parameter was threaded into all four audit functions, but only `AuditUnconstrainedDelegations` has a Legitimate/Suspicious classification to act on (a Domain Controller is a legitimate holder of unconstrained delegation). The constrained, constrained-with-protocol-transition, and resource-based constrained audits have no notion of a "legitimate" entry — they only list the configured delegation targets/identities — so the parameter was accepted and never read. Go does not flag unused function parameters, so this dead parameter compiled silently and made the signatures dishonest about what the flag affects.

### Fix Description
Removes the unused `ignoreLegitimate` parameter from `AuditConstrainedDelegations`, `AuditConstrainedDelegationsWithProtocolTransition`, and `AuditRessourceBasedConstrainedDelegations`, and drops the corresponding argument from their three call sites in `main.go`. The `-I/--ignore-legitimate` flag and its only meaningful behavior (in `AuditUnconstrainedDelegations`) are untouched, so the CLI is unchanged for users.

The alternative — inventing a "legitimate" classification for constrained/RBCD delegations — was rejected: there is no well-defined legitimate baseline for those types, so any such filter would be arbitrary and out of scope for this fix.

### How Verified
- `go build ./...` — succeeds.
- `go vet ./...` — clean.
- `go run . audit --help` — still lists `-I, --ignore-legitimate`, confirming the flag remains wired up and functional (consumed by the unconstrained audit).

### Test Coverage
- **None:** the repository has no test suite for the audit command paths, and this change removes dead parameters without altering runtime behavior. Verified via build, vet, and the CLI help output above.

### Scope of Change
- **Files changed:** `main.go`, `mode_audit/ConstrainedDelegations.go`, `mode_audit/ConstrainedDelegationsWithProtocolTransition.go`, `mode_audit/RessourceBasedConstrainedDelegations.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, low blast radius: removes parameters that were never read and updates internal call sites only. No user-facing or behavioral change; safe to merge directly.